### PR TITLE
Added support for using both the "with" and "for" keywords when using…

### DIFF
--- a/tags/include.go
+++ b/tags/include.go
@@ -2,6 +2,8 @@ package tags
 
 import (
 	"io"
+	"path/filepath"
+	"strings"
 
 	"github.com/acstech/liquid/core"
 )
@@ -15,13 +17,27 @@ func IncludeFactory(p *core.Parser, config *core.Configuration) (core.Tag, error
 	if value == nil {
 		return nil, p.Error("Invalid include value")
 	}
+
+	scopeType := p.ReadName()
+	var scope core.Value
+	if scopeType == "with" || scopeType == "for" {
+		scope, err = p.ReadValue()
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		scopeType = ""
+	}
+
 	p.SkipPastTag()
-	return &Include{value, config.GetIncludeHandler()}, nil
+	return &Include{value, config.GetIncludeHandler(), scopeType, scope}, nil
 }
 
 type Include struct {
-	value   core.Value
-	handler core.IncludeHandler
+	value     core.Value
+	handler   core.IncludeHandler
+	scopeType string
+	scope     core.Value
 }
 
 func (i *Include) AddCode(code core.Code) {
@@ -33,10 +49,60 @@ func (i *Include) AddSibling(tag core.Tag) error {
 }
 
 func (i *Include) Execute(writer io.Writer, data map[string]interface{}) core.ExecuteState {
+	template := core.ToString(i.value.Resolve(data))
+	_, filename := filepath.Split(template)
+	extension := filepath.Ext(filename)
+	name := filename[0 : len(filename)-len(extension)]
+	contextVariableName := strings.ToLower(name)
+
+	var templateData = make([]map[string]interface{}, 1)
+
+	switch i.scopeType {
+	case "with":
+		scopedData := i.scope.Resolve(data)
+		templateData[0] = toMap(scopedData, contextVariableName)
+	case "for":
+		scopedData := i.scope.Resolve(data)
+
+		switch typed := scopedData.(type) {
+		case []interface{}:
+			templateData = make([]map[string]interface{}, len(typed))
+			for i, item := range typed {
+				templateData[i] = toMap(item, contextVariableName)
+			}
+		case []map[string]interface{}:
+			templateData = make([]map[string]interface{}, len(typed))
+			for i, item := range typed {
+				templateData[i] = toMap(item, contextVariableName)
+			}
+		default:
+			templateData[0] = toMap(scopedData, contextVariableName)
+		}
+	default:
+		templateData[0] = data
+	}
+
 	if i.handler != nil {
-		i.handler(core.ToString(i.value.Resolve(data)), writer, data)
+		for _, item := range templateData {
+			i.handler(template, writer, item)
+		}
 	}
 	return core.Normal
+}
+
+func toMap(data interface{}, contextVariableName string) map[string]interface{} {
+	if data == nil {
+		return nil
+	}
+
+	var context map[string]interface{}
+	if typed, ok := data.(map[string]interface{}); ok {
+		context = typed
+	} else {
+		context := make(map[string]interface{})
+		context[contextVariableName] = typed
+	}
+	return context
 }
 
 func (i *Include) Name() string {

--- a/tags/include.go
+++ b/tags/include.go
@@ -93,14 +93,12 @@ func toMap(data interface{}, contextVariableName string) map[string]interface{} 
 		return nil
 	}
 
-	var context map[string]interface{}
 	if typed, ok := data.(map[string]interface{}); ok {
-		context = typed
-	} else {
-		context = make(map[string]interface{})
-		context[contextVariableName] = data
+		return typed
 	}
 
+	context := make(map[string]interface{})
+	context[contextVariableName] = data
 	return context
 }
 

--- a/tags/include.go
+++ b/tags/include.go
@@ -1,7 +1,6 @@
 package tags
 
 import (
-	"fmt"
 	"io"
 	"path/filepath"
 	"reflect"
@@ -82,7 +81,6 @@ func (i *Include) Execute(writer io.Writer, data map[string]interface{}) core.Ex
 				templateData[i] = toMap(slice.Index(i).Interface(), contextVariableName)
 			}
 		default:
-			fmt.Printf("Scoped Data: %+v\n", scopedData)
 			templateData[0] = toMap(scopedData, contextVariableName)
 		}
 	default:

--- a/tags/include_test.go
+++ b/tags/include_test.go
@@ -1,0 +1,80 @@
+package tags
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/acstech/liquid"
+	"github.com/karlseguin/gspec"
+)
+
+func TestIncludeFactory(t *testing.T) {
+	spec := gspec.New(t)
+	parser := newParser("'test' %}Z")
+	tag, err := IncludeFactory(parser, liquid.Configure())
+	spec.Expect(err).ToBeNil()
+	spec.Expect(tag.Name()).ToEqual("include")
+	spec.Expect(parser.Current()).ToEqual(byte('Z'))
+}
+
+func TestIncludeTagExecutes(t *testing.T) {
+	spec := gspec.New(t)
+	parser := newParser("'test' %}")
+	testData := make(map[string]interface{})
+	testData["key"] = "test"
+
+	config := liquid.Configure().IncludeHandler(func(name string, writer io.Writer, data map[string]interface{}) {
+		writer.Write([]byte(fmt.Sprintf("%v", data["key"])))
+	})
+	tag, err := IncludeFactory(parser, config)
+
+	spec.Expect(err).ToBeNil()
+
+	writer := new(bytes.Buffer)
+	tag.Execute(writer, testData)
+	spec.Expect(writer.String()).ToEqual(testData["key"])
+}
+
+func TestIncludeTagWithExecutes(t *testing.T) {
+	spec := gspec.New(t)
+	parser := newParser("'test' with context %}")
+	testData := make(map[string]interface{})
+	testContext := make(map[string]interface{})
+	testContext["key"] = "test"
+	testData["context"] = testContext
+
+	config := liquid.NoCache.IncludeHandler(func(name string, writer io.Writer, data map[string]interface{}) {
+		writer.Write([]byte(fmt.Sprintf("%v", data["key"])))
+	})
+	tag, err := IncludeFactory(parser, config)
+
+	spec.Expect(err).ToBeNil()
+
+	writer := new(bytes.Buffer)
+	tag.Execute(writer, testData)
+	spec.Expect(writer.String()).ToEqual(testContext["key"])
+}
+
+func TestIncludeTagForExecutes(t *testing.T) {
+	spec := gspec.New(t)
+	parser := newParser("'test' for context %}")
+	testData := make(map[string]interface{})
+	testArray := make([]string, 3)
+	testArray[0] = "1"
+	testArray[1] = "2"
+	testArray[2] = "3"
+	testData["context"] = testArray
+
+	config := liquid.NoCache.IncludeHandler(func(name string, writer io.Writer, data map[string]interface{}) {
+		writer.Write([]byte(fmt.Sprintf("%v", data["test"])))
+	})
+	tag, err := IncludeFactory(parser, config)
+
+	spec.Expect(err).ToBeNil()
+
+	writer := new(bytes.Buffer)
+	tag.Execute(writer, testData)
+	spec.Expect(writer.String()).ToEqual("123")
+}

--- a/tags/include_test.go
+++ b/tags/include_test.go
@@ -6,14 +6,14 @@ import (
 	"io"
 	"testing"
 
-	"github.com/acstech/liquid"
+	"github.com/acstech/liquid/core"
 	"github.com/karlseguin/gspec"
 )
 
 func TestIncludeFactory(t *testing.T) {
 	spec := gspec.New(t)
 	parser := newParser("'test' %}Z")
-	tag, err := IncludeFactory(parser, liquid.Configure())
+	tag, err := IncludeFactory(parser, new(core.Configuration))
 	spec.Expect(err).ToBeNil()
 	spec.Expect(tag.Name()).ToEqual("include")
 	spec.Expect(parser.Current()).ToEqual(byte('Z'))
@@ -25,7 +25,7 @@ func TestIncludeTagExecutes(t *testing.T) {
 	testData := make(map[string]interface{})
 	testData["key"] = "test"
 
-	config := liquid.Configure().IncludeHandler(func(name string, writer io.Writer, data map[string]interface{}) {
+	config := new(core.Configuration).IncludeHandler(func(name string, writer io.Writer, data map[string]interface{}) {
 		writer.Write([]byte(fmt.Sprintf("%v", data["key"])))
 	})
 	tag, err := IncludeFactory(parser, config)
@@ -45,7 +45,7 @@ func TestIncludeTagWithExecutes(t *testing.T) {
 	testContext["key"] = "test"
 	testData["context"] = testContext
 
-	config := liquid.NoCache.IncludeHandler(func(name string, writer io.Writer, data map[string]interface{}) {
+	config := new(core.Configuration).IncludeHandler(func(name string, writer io.Writer, data map[string]interface{}) {
 		writer.Write([]byte(fmt.Sprintf("%v", data["key"])))
 	})
 	tag, err := IncludeFactory(parser, config)
@@ -60,6 +60,7 @@ func TestIncludeTagWithExecutes(t *testing.T) {
 func TestIncludeTagForExecutes(t *testing.T) {
 	spec := gspec.New(t)
 	parser := newParser("'test' for context %}")
+
 	testData := make(map[string]interface{})
 	testArray := make([]string, 3)
 	testArray[0] = "1"
@@ -67,7 +68,7 @@ func TestIncludeTagForExecutes(t *testing.T) {
 	testArray[2] = "3"
 	testData["context"] = testArray
 
-	config := liquid.NoCache.IncludeHandler(func(name string, writer io.Writer, data map[string]interface{}) {
+	config := new(core.Configuration).IncludeHandler(func(name string, writer io.Writer, data map[string]interface{}) {
 		writer.Write([]byte(fmt.Sprintf("%v", data["test"])))
 	})
 	tag, err := IncludeFactory(parser, config)


### PR DESCRIPTION
… the include tag.

For example:

{% include 'product' with products[0] %}

and

{% include 'product' for products %}

@joshua @acstech/echo 
