### PR TITLE
Added ability to pass comma separated parameters to the include tag.

### DIFF
--- a/tags/include.go
+++ b/tags/include.go
@@ -96,7 +96,7 @@ func (i *Include) Execute(writer io.Writer, data map[string]interface{}) core.Ex
 	contextVariableName := strings.ToLower(name)
 
 	var templateData = make([]map[string]interface{}, 1)
-	var parameterData = make(map[string]interface{})
+	var parameterData = make(map[string]interface{}, len(i.parameters))
 
 	// Resolve values for all our parameters
 	for name, value := range i.parameters {

--- a/tags/include.go
+++ b/tags/include.go
@@ -19,27 +19,65 @@ func IncludeFactory(p *core.Parser, config *core.Configuration) (core.Tag, error
 		return nil, p.Error("Invalid include value")
 	}
 
-	scopeType := p.ReadName()
+	var scopeType string
 	var scope core.Value
+	var params map[string]core.Value
 
-	if scopeType == "with" || scopeType == "for" {
-		scope, err = p.ReadValue()
+	if p.SkipSpaces() == ',' {
+		params, err = readParameters(p)
 		if err != nil {
 			return nil, err
 		}
 	} else {
-		scopeType = ""
+		scopeType = p.ReadName()
+
+		if scopeType == "with" || scopeType == "for" {
+			scope, err = p.ReadValue()
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		if p.SkipSpaces() == ',' {
+			params, err = readParameters(p)
+			if err != nil {
+				return nil, err
+			}
+		}
 	}
 
 	p.SkipPastTag()
-	return &Include{value, config.GetIncludeHandler(), scopeType, scope}, nil
+	return &Include{value, config.GetIncludeHandler(), scopeType, scope, params}, nil
+}
+
+func readParameters(p *core.Parser) (map[string]core.Value, error) {
+	p.Forward()
+	parameters := make(map[string]core.Value)
+
+	for name := p.ReadName(); name != ""; name = p.ReadName() {
+		if p.SkipSpaces() == ':' {
+			p.Forward()
+			value, err := p.ReadValue()
+			if err != nil {
+				return nil, err
+			}
+			parameters[name] = value
+		}
+
+		if p.SkipSpaces() == ',' {
+			p.Forward()
+		}
+	}
+
+	return parameters, nil
 }
 
 type Include struct {
-	value     core.Value
-	handler   core.IncludeHandler
-	scopeType string
-	scope     core.Value
+	value      core.Value
+	handler    core.IncludeHandler
+	scopeType  string
+	scope      core.Value
+	parameters map[string]core.Value
 }
 
 func (i *Include) AddCode(code core.Code) {
@@ -58,6 +96,12 @@ func (i *Include) Execute(writer io.Writer, data map[string]interface{}) core.Ex
 	contextVariableName := strings.ToLower(name)
 
 	var templateData = make([]map[string]interface{}, 1)
+	var parameterData = make(map[string]interface{})
+
+	// Resolve values for all our parameters
+	for name, value := range i.parameters {
+		parameterData[name] = value.Resolve(data)
+	}
 
 	switch i.scopeType {
 	case "with":
@@ -89,6 +133,10 @@ func (i *Include) Execute(writer io.Writer, data map[string]interface{}) core.Ex
 
 	if i.handler != nil {
 		for _, item := range templateData {
+			// Inject our parameters into the data context for the template
+			for name, value := range parameterData {
+				item[name] = value
+			}
 			i.handler(template, writer, item)
 		}
 	}

--- a/tags/include_test.go
+++ b/tags/include_test.go
@@ -79,3 +79,41 @@ func TestIncludeTagForExecutes(t *testing.T) {
 	tag.Execute(writer, testData)
 	spec.Expect(writer.String()).ToEqual("123")
 }
+
+func TestIncludeTagWithParameters(t *testing.T) {
+	spec := gspec.New(t)
+	parser := newParser("'test', test1:'A', test2:'B' %}")
+	testData := make(map[string]interface{})
+	testData["key"] = "test"
+
+	config := new(core.Configuration).IncludeHandler(func(name string, writer io.Writer, data map[string]interface{}) {
+		writer.Write([]byte(fmt.Sprintf("%v,%v,%v", data["key"], data["test1"], data["test2"])))
+	})
+	tag, err := IncludeFactory(parser, config)
+
+	spec.Expect(err).ToBeNil()
+
+	writer := new(bytes.Buffer)
+	tag.Execute(writer, testData)
+	spec.Expect(writer.String()).ToEqual("test,A,B")
+}
+
+func TestIncludeTagWithWithParametersExecutes(t *testing.T) {
+	spec := gspec.New(t)
+	parser := newParser("'test' with context, test1: 'A', test2: 'B' %}")
+	testData := make(map[string]interface{})
+	testContext := make(map[string]interface{})
+	testContext["key"] = "test"
+	testData["context"] = testContext
+
+	config := new(core.Configuration).IncludeHandler(func(name string, writer io.Writer, data map[string]interface{}) {
+		writer.Write([]byte(fmt.Sprintf("%v,%v,%v", data["key"], data["test1"], data["test2"])))
+	})
+	tag, err := IncludeFactory(parser, config)
+
+	spec.Expect(err).ToBeNil()
+
+	writer := new(bytes.Buffer)
+	tag.Execute(writer, testData)
+	spec.Expect(writer.String()).ToEqual("test,A,B")
+}


### PR DESCRIPTION
@joshua 
I added the ability to pass in a comma separate list of parameters to the include tag. This allows the template creator to do something like:
{% include 'template.liq' with item, param1: 'some value', param2: 123, param3: valueFromContext %}
