### PR TITLE
fix an issue with nested conditional tags

### DIFF
--- a/core/tag.go
+++ b/core/tag.go
@@ -5,6 +5,7 @@ package core
 type Tag interface {
 	AddCode(code Code)
 	AddSibling(tag Tag) error
+	LastSibling() Tag
 	Name() string
 	Type() TagType
 	Code

--- a/tags/assign.go
+++ b/tags/assign.go
@@ -42,6 +42,10 @@ func (a *Assign) AddSibling(tag core.Tag) error {
 	panic("AddSibling should not have been called on a Assign")
 }
 
+func (a *Assign) LastSibling() core.Tag {
+	return nil
+}
+
 func (a *Assign) Execute(writer io.Writer, data map[string]interface{}) core.ExecuteState {
 	value := a.value.Resolve(data)
 	if a.filters != nil {

--- a/tags/break.go
+++ b/tags/break.go
@@ -24,6 +24,10 @@ func (b *Break) AddSibling(tag core.Tag) error {
 	panic("AddSibling should not have been called on a Break")
 }
 
+func (b *Break) LastSibling() core.Tag {
+	return nil
+}
+
 func (b *Break) Execute(writer io.Writer, data map[string]interface{}) core.ExecuteState {
 	return core.Break
 }

--- a/tags/capture.go
+++ b/tags/capture.go
@@ -33,6 +33,10 @@ func (c *Capture) AddSibling(tag core.Tag) error {
 	return errors.New(fmt.Sprintf("%q tag does not belong directly within a capture", tag.Name()))
 }
 
+func (c *Capture) LastSibling() core.Tag {
+	return nil
+}
+
 func (c *Capture) Execute(w io.Writer, data map[string]interface{}) core.ExecuteState {
 	writer := core.BytePool.Checkout()
 	defer writer.Close()

--- a/tags/case.go
+++ b/tags/case.go
@@ -24,7 +24,7 @@ func CaseFactory(p *core.Parser, config *core.Configuration) (core.Tag, error) {
 		return nil, err
 	}
 	p.SkipPastTag()
-	return &Case{value, make([]CaseSibling, 0, 5)}, nil
+	return &Case{value, make([]CaseSibling, 0, 5), nil}, nil
 }
 
 func WhenFactory(p *core.Parser, config *core.Configuration) (core.Tag, error) {
@@ -41,8 +41,9 @@ func EndCaseFactory(p *core.Parser, config *core.Configuration) (core.Tag, error
 }
 
 type Case struct {
-	value      core.Value
-	conditions []CaseSibling
+	value       core.Value
+	conditions  []CaseSibling
+	lastSibling core.Tag
 }
 
 func (c *Case) AddCode(code core.Code) {}
@@ -54,7 +55,12 @@ func (c *Case) AddSibling(tag core.Tag) error {
 	}
 	c.conditions = append(c.conditions, cs)
 	cs.AddLeftValue(c.value)
+	c.lastSibling = tag
 	return nil
+}
+
+func (c *Case) LastSibling() core.Tag {
+	return c.lastSibling
 }
 
 func (c *Case) Execute(writer io.Writer, data map[string]interface{}) core.ExecuteState {
@@ -81,6 +87,10 @@ type When struct {
 
 func (w *When) AddSibling(tag core.Tag) error {
 	panic("AddSibling should not have been called on a when")
+}
+
+func (w *When) LastSibling() core.Tag {
+	return nil
 }
 
 func (w *When) Name() string {

--- a/tags/comment.go
+++ b/tags/comment.go
@@ -53,6 +53,10 @@ func (c *Comment) AddSibling(tag core.Tag) error {
 	panic("AddSibling should not have been called on a comment")
 }
 
+func (c *Comment) LastSibling() core.Tag {
+	return nil
+}
+
 func (c *Comment) Execute(writer io.Writer, data map[string]interface{}) core.ExecuteState {
 	panic("Render should not have been called on a comment")
 }

--- a/tags/continue.go
+++ b/tags/continue.go
@@ -24,6 +24,10 @@ func (c *Continue) AddSibling(tag core.Tag) error {
 	panic("AddSibling should not have been called on a Continue")
 }
 
+func (c *Continue) LastSibling() core.Tag {
+	return nil
+}
+
 func (c *Continue) Execute(writer io.Writer, data map[string]interface{}) core.ExecuteState {
 	return core.Continue
 }

--- a/tags/end.go
+++ b/tags/end.go
@@ -19,6 +19,10 @@ func (e *End) AddSibling(tag core.Tag) error {
 	panic("AddSibling should not have been called on an end tag")
 }
 
+func (e *End) LastSibling() core.Tag {
+	return nil
+}
+
 func (e *End) Execute(writer io.Writer, data map[string]interface{}) core.ExecuteState {
 	panic("Render should not have been called on an end tag")
 }

--- a/tags/for.go
+++ b/tags/for.go
@@ -90,6 +90,10 @@ func (f *For) AddSibling(tag core.Tag) error {
 	return errors.New(fmt.Sprintf("%q does not belong inside of a for", tag.Name()))
 }
 
+func (f *For) LastSibling() core.Tag {
+	return nil
+}
+
 func (f *For) Execute(writer io.Writer, data map[string]interface{}) core.ExecuteState {
 	value := reflect.ValueOf(f.value.Resolve(data))
 	kind := value.Kind()

--- a/tags/if.go
+++ b/tags/if.go
@@ -26,6 +26,7 @@ func IfFactory(p *core.Parser, config *core.Configuration) (core.Tag, error) {
 		NewCommon(),
 		condition,
 		make([]IfSibling, 0, 3),
+		nil,
 	}
 	i.conditions = append(i.conditions, i)
 	p.SkipPastTag()
@@ -52,8 +53,9 @@ func EndIfFactory(p *core.Parser, config *core.Configuration) (core.Tag, error) 
 
 type If struct {
 	*Common
-	condition  core.Verifiable
-	conditions []IfSibling
+	condition   core.Verifiable
+	conditions  []IfSibling
+	lastSibling core.Tag
 }
 
 func (i *If) AddSibling(tag core.Tag) error {
@@ -62,7 +64,12 @@ func (i *If) AddSibling(tag core.Tag) error {
 		return errors.New(fmt.Sprintf("%q does not belong inside of an if"))
 	}
 	i.conditions = append(i.conditions, ifs)
+	i.lastSibling = tag
 	return nil
+}
+
+func (i *If) LastSibling() core.Tag {
+	return i.lastSibling
 }
 
 func (i *If) Execute(writer io.Writer, data map[string]interface{}) core.ExecuteState {
@@ -99,6 +106,10 @@ func (e *ElseIf) AddSibling(tag core.Tag) error {
 	panic("AddSibling should not have been called on a elseif")
 }
 
+func (e *ElseIf) LastSibling() core.Tag {
+	return nil
+}
+
 func (e *ElseIf) Name() string {
 	return "elseif"
 }
@@ -118,6 +129,10 @@ type Else struct {
 
 func (e *Else) AddSibling(tag core.Tag) error {
 	panic("AddSibling should not have been called on a else")
+}
+
+func (e *Else) LastSibling() core.Tag {
+	return nil
 }
 
 func (e *Else) Name() string {

--- a/tags/include.go
+++ b/tags/include.go
@@ -88,6 +88,10 @@ func (i *Include) AddSibling(tag core.Tag) error {
 	panic("AddSibling should not have been called on a Include")
 }
 
+func (i *Include) LastSibling() core.Tag {
+	return nil
+}
+
 func (i *Include) Execute(writer io.Writer, data map[string]interface{}) core.ExecuteState {
 	template := core.ToString(i.value.Resolve(data))
 	_, filename := filepath.Split(template)

--- a/tags/raw.go
+++ b/tags/raw.go
@@ -50,6 +50,10 @@ func (r *Raw) AddSibling(tag core.Tag) error {
 	panic("AddSibling should not have been called on a Raw")
 }
 
+func (r *Raw) LastSibling() core.Tag {
+	return nil
+}
+
 func (r *Raw) Execute(writer io.Writer, data map[string]interface{}) core.ExecuteState {
 	writer.Write(r.value)
 	return core.Normal

--- a/tags/unless.go
+++ b/tags/unless.go
@@ -41,6 +41,10 @@ func (u *Unless) AddSibling(tag core.Tag) error {
 	return nil
 }
 
+func (u *Unless) LastSibling() core.Tag {
+	return u.elseCondition
+}
+
 func (u *Unless) Execute(writer io.Writer, data map[string]interface{}) core.ExecuteState {
 	if u.condition.IsTrue(data) {
 		return u.Common.Execute(writer, data)

--- a/template.go
+++ b/template.go
@@ -23,6 +23,10 @@ func (t *Template) AddSibling(tag core.Tag) error {
 	return nil
 }
 
+func (t *Template) LastSibling() core.Tag {
+	return nil
+}
+
 func (t *Template) Type() core.TagType {
 	return core.ContainerTag
 }
@@ -129,6 +133,9 @@ func extractTokens(parser *core.Parser, container core.Tag, config *core.Configu
 				}
 				stack = stack[0:l]
 				container = stack[l-1]
+				if (container.LastSibling() != nil) {
+					container = container.LastSibling()
+				}
 				parser.SkipPastTag()
 			case core.SiblingTag:
 				if err := stack[len(stack)-1].AddSibling(tag); err != nil {

--- a/template_test.go
+++ b/template_test.go
@@ -146,6 +146,148 @@ func TestTemplateRender1(t *testing.T) {
 	assertRender(t, template, d, "\nOut of\n\n- white \n- red \n- blue  \nYour favorite color was blue.\n---\n\nYoungn'\n\n---\n  0 is 68    2 is 110  ")
 }
 
+var complexNestedIfTemplate = `
+{% if false %}
+	x
+{% elseif false %}
+	x
+{% else %}
+	{% if false %}
+		x
+	{% elseif true %}
+
+		{% if true %}
+			1
+		{% elseif false %}
+			{% if true %}
+			x
+			{% else %}
+			x
+			{% endif %}
+
+			x
+		{% else %}
+			{% if true %}
+			x
+			{% else %}
+			x
+			{% endif %}
+
+			x
+		{% endif %}
+
+		2
+
+		{% if true %}
+			3
+		{% elseif false %}
+			{% if true %}
+			x
+			{% else %}
+			x
+			{% endif %}
+
+			x
+		{% else %}
+			{% if true %}
+			x
+			{% else %}
+			x
+			{% endif %}
+
+			x
+		{% endif %}
+	{% else %}
+		{% if true %}
+		x
+		{% else %}
+		x
+		{% endif %}
+
+		x
+	{% endif %}
+
+	4
+{% endif %}
+
+5`
+
+func TestTemplateRenderNestedIf(t *testing.T) {
+	d := map[string]interface{}{}
+	template, _ := ParseString(complexNestedIfTemplate, nil)
+	assertRender(t, template, d, " \n\t\n\n\t\t\n\t\t\t1\n\t\t\n\n\t\t2\n\n\t\t\n\t\t\t3\n\t\t\n\t\n\n\t4\n\n\n5")
+}
+
+var complexNestedCaseWithIfTemplate = `
+{% case a %}
+	{% when 0 %}
+		x
+	{% when 1 %}
+
+		{% case b %}
+			{% when 0 %}
+				x
+			{% when 1 %}
+				x
+			{% else %}
+				{% if true %}
+					1
+				{% elseif false %}
+					{% if true %}
+					x
+					{% else %}
+					x
+					{% endif %}
+
+					x
+				{% else %}
+					{% if true %}
+					x
+					{% else %}
+					x
+					{% endif %}
+
+					x
+				{% endif %}
+
+				2
+
+				{% if true %}
+					3
+				{% elseif false %}
+					{% if true %}
+					x
+					{% else %}
+					x
+					{% endif %}
+
+					x
+				{% else %}
+					{% if true %}
+					x
+					{% else %}
+					x
+					{% endif %}
+
+					x
+				{% endif %}
+		{% endcase %}
+
+		4
+	{% when 2 %}
+		x
+	{% else %}
+		x
+{% endcase %}
+
+5`
+
+func TestTemplateRenderNestedCaseAndIf(t *testing.T) {
+	d := map[string]interface{}{ "a" : 1, "b" : 2 }
+	template, _ := ParseString(complexNestedCaseWithIfTemplate, nil)
+	assertRender(t, template, d, " \n\n\t\t\n\t\t\t\t\n\t\t\t\t\t1\n\t\t\t\t\n\n\t\t\t\t2\n\n\t\t\t\t\n\t\t\t\t\t3\n\t\t\t\t\n\t\t\n\n\t\t4\n\t\n\n5")
+}
+
 func BenchmarkParseTemplateWithoutCache(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		ParseString(complexTemplate, NoCache)


### PR DESCRIPTION
@joshua @ianmburns 

This fixes an issue with nested conditional tags.

Let's see if I can explain what was going on. Given the the following template:

```
	{% if true %}
		Foo 1
	{% else %}
		{% if true %}
			Bar 1
		{% else %}
			Bar 2
		{% endif %}
		
		Foo 2
	{% endif %}
```

The output we were seeing was:
```

	Foo 1

	Foo 2

```

This is because, after the nested if is closed with the endif, the 'container' in the template processor was being set to the initial "if" statement instead of the "else" statement (template.go -> extractTokens -> container = stack[l-1]). The stack itself only contains the if statements, so the container is set incorrectly. We need to instead get a reference to the if statements last "sibling" which will be the container we actually need.




