### PR TITLE
Feature/ordinal days

### DIFF
--- a/filters/date.go
+++ b/filters/date.go
@@ -1,6 +1,7 @@
 package filters
 
 import (
+	"strings"
 	"time"
 
 	"github.com/acstech/go-strftime"
@@ -8,27 +9,53 @@ import (
 )
 
 var (
-	zeroTime = time.Time{}
+	zeroTime         = time.Time{}
+	timeInputFormats = []string{
+		"2006-01-02 15:04:05 -0700",
+		"2006-01-02 15:04:05",
+		"2006-01-02",
+		"2006-01-02T15:04:05",
+		"2006-01-02T15:04:05Z",
+		"1/2/2006 03:04:05 PM",
+		"1/2/2006 3:04:05 PM",
+		"1/2/2006",
+		"1/2/2006 15:04:05",
+	}
 )
 
-// Creates an date filter
+// DateFactory creates an date filter
 func DateFactory(parameters []core.Value) core.Filter {
-	if len(parameters) == 0 {
+	switch len(parameters) {
+	case 1:
+		return (&DateFilter{parameters[0], nil}).ToString
+	case 2:
+		return (&DateFilter{parameters[0], parameters[1]}).ToString
+	default:
 		return Noop
 	}
-	return (&DateFilter{parameters[0]}).ToString
 }
 
+// DateFilter ...
 type DateFilter struct {
 	format core.Value
+	offset core.Value
 }
 
+// ToString converts input to formatted date string
 func (d *DateFilter) ToString(input interface{}, data map[string]interface{}) interface{} {
-	time, ok := inputToTime(input)
+	t, ok := inputToTime(input)
 	if ok == false {
 		return input
 	}
-	return strftime.Strftime(&time, core.ToString(d.format.Resolve(data)))
+
+	if d.offset != nil {
+		if offset, ok := core.ToInt(d.offset.Resolve(data)); ok {
+			t = t.Add(time.Duration(offset) * time.Hour)
+		}
+	}
+
+	format := processOrdinalDay(core.ToString(d.format.Resolve(data)), t)
+	return strftime.Strftime(&t, format)
 }
 
 func inputToTime(input interface{}) (time.Time, bool) {
@@ -50,9 +77,37 @@ func timeFromString(s string) (time.Time, bool) {
 	if s == "now" || s == "today" {
 		return core.Now(), true
 	}
-	t, err := time.Parse("2006-01-02 15:04:05 -0700", s)
-	if err != nil {
-		return zeroTime, false
+
+	for _, f := range timeInputFormats {
+		t, err := time.Parse(f, s)
+		if err == nil {
+			return t, true
+		}
+
 	}
-	return t, true
+
+	return zeroTime, false
+}
+
+func processOrdinalDay(format string, time time.Time) string {
+	if strings.Contains(format, "%O") {
+		ordinal := "%-dth"
+		day := time.Day()
+		if !(day > 10 && day < 14) {
+			switch day % 10 {
+			case 1:
+				ordinal = "%-dst"
+				break
+			case 2:
+				ordinal = "%-dnd"
+				break
+			case 3:
+				ordinal = "%-drd"
+				break
+			}
+		}
+		return strings.Replace(format, "%O", ordinal, -1)
+	}
+
+	return format
 }

--- a/filters/date.go
+++ b/filters/date.go
@@ -26,6 +26,8 @@ var (
 // DateFactory creates an date filter
 func DateFactory(parameters []core.Value) core.Filter {
 	switch len(parameters) {
+	case 0:
+		return Noop
 	case 1:
 		return (&DateFilter{format: parameters[0]}).ToString
 	case 2:
@@ -33,19 +35,13 @@ func DateFactory(parameters []core.Value) core.Filter {
 		case *core.StaticIntValue, *core.StaticFloatValue:
 			return (&DateFilter{format: parameters[0], offset: parameters[1]}).ToString
 		}
-
 		return (&DateFilter{format: parameters[0], inputFormat: parameters[1]}).ToString
-
-	case 3:
+	default:
 		switch parameters[1].(type) {
 		case *core.StaticIntValue, *core.StaticFloatValue:
 			return (&DateFilter{format: parameters[0], offset: parameters[1], inputFormat: parameters[2]}).ToString
 		}
-
 		return (&DateFilter{format: parameters[0], inputFormat: parameters[1], offset: parameters[2]}).ToString
-
-	default:
-		return Noop
 	}
 }
 

--- a/filters/date_test.go
+++ b/filters/date_test.go
@@ -32,3 +32,50 @@ func TestDateWithSillyFormat(t *testing.T) {
 	filter := DateFactory([]core.Value{stringValue("%w  %U  %j")})
 	spec.Expect(filter("2014-01-10 21:31:28 +0800", nil).(string)).ToEqual("5  02  10")
 }
+
+func TestDateWithOffset(t *testing.T) {
+	spec := gspec.New(t)
+	filter := DateFactory([]core.Value{stringValue("%Y %m %d %H %M %S"), intValue(5)})
+	spec.Expect(filter("now", nil).(string)).ToEqual("2006 01 02 20 04 05")
+}
+
+func TestDateOrdinalDays(t *testing.T) {
+	spec := gspec.New(t)
+	testFormat := func(test *testing.T, input string, format string, assert string) {
+		filter := DateFactory([]core.Value{stringValue(format)})
+
+		spec.Expect(filter(input, nil).(string)).ToEqual(assert)
+	}
+
+	testFormat(t, "1/1/2016", "%O", "1st")
+	testFormat(t, "1/2/2016", "%O", "2nd")
+	testFormat(t, "1/3/2016", "%O", "3rd")
+	testFormat(t, "1/4/2016", "%O", "4th")
+	testFormat(t, "1/5/2016", "%O", "5th")
+	testFormat(t, "1/6/2016", "%O", "6th")
+	testFormat(t, "1/7/2016", "%O", "7th")
+	testFormat(t, "1/8/2016", "%O", "8th")
+	testFormat(t, "1/9/2016", "%O", "9th")
+	testFormat(t, "1/10/2016", "%O", "10th")
+	testFormat(t, "1/11/2016", "%O", "11th")
+	testFormat(t, "1/12/2016", "%O", "12th")
+	testFormat(t, "1/13/2016", "%O", "13th")
+	testFormat(t, "1/14/2016", "%O", "14th")
+	testFormat(t, "1/15/2016", "%O", "15th")
+	testFormat(t, "1/16/2016", "%O", "16th")
+	testFormat(t, "1/17/2016", "%O", "17th")
+	testFormat(t, "1/18/2016", "%O", "18th")
+	testFormat(t, "1/19/2016", "%O", "19th")
+	testFormat(t, "1/20/2016", "%O", "20th")
+	testFormat(t, "1/21/2016", "%O", "21st")
+	testFormat(t, "1/22/2016", "%O", "22nd")
+	testFormat(t, "1/23/2016", "%O", "23rd")
+	testFormat(t, "1/24/2016", "%O", "24th")
+	testFormat(t, "1/25/2016", "%O", "25th")
+	testFormat(t, "1/26/2016", "%O", "26th")
+	testFormat(t, "1/27/2016", "%O", "27th")
+	testFormat(t, "1/28/2016", "%O", "28th")
+	testFormat(t, "1/29/2016", "%O", "29th")
+	testFormat(t, "1/30/2016", "%O", "30th")
+	testFormat(t, "1/31/2016", "%O", "31st")
+}


### PR DESCRIPTION
@joshua We want to add a broader range of support to the date filter. There are a few features we would like to implement:

More date formats. See the timeInputFormats array. And the ability to specify an incoming date format string if it's not in the list of supported types.

Adding an hourly 'offset' option to adjust the date time to a different timezone

Adding the ability to specify an ordinal format for the day. So you can say 1st or 2nd. We wanted to keep the strftime implementation as close to the source as possible, so this is done before hand by replacing the key %0 with the appropriate ordinal phrase and day modifier.

