### PR TITLE
Rewriting include tag to properly match liquid source

### DIFF
--- a/tags/include.go
+++ b/tags/include.go
@@ -9,75 +9,79 @@ import (
 	"github.com/acstech/liquid/core"
 )
 
+const includeWithScopeType = "with"
+const includeForScopeType = "for"
+
 // Creates an include tag
 func IncludeFactory(p *core.Parser, config *core.Configuration) (core.Tag, error) {
-	value, err := p.ReadValue()
+	includeName, err := p.ReadValue()
 	if err != nil {
 		return nil, err
 	}
-	if value == nil {
+	if includeName == nil {
 		return nil, p.Error("Invalid include value")
 	}
 
 	var scopeType string
+	var scopeKey string
 	var scope core.Value
-	var params map[string]core.Value
+	params := make(map[string]core.Value)
 
-	if p.SkipSpaces() == ',' {
-		params, err = readParameters(p)
-		if err != nil {
-			return nil, err
-		}
-	} else {
+	var next = p.SkipSpaces()
+	if next == 'w' || next == 'f' {
 		scopeType = p.ReadName()
 
-		if scopeType == "with" || scopeType == "for" {
+		if scopeType == includeWithScopeType || scopeType == includeForScopeType {
+			includeNameString := core.ToString(includeName.Resolve(nil))
+			scopeKey = strings.TrimSuffix(includeNameString, filepath.Ext(includeNameString))
+
 			scope, err = p.ReadValue()
 			if err != nil {
 				return nil, err
 			}
 		}
 
-		if p.SkipSpaces() == ',' {
-			params, err = readParameters(p)
-			if err != nil {
-				return nil, err
+		next = p.SkipSpaces()
+	}
+
+	if next == ',' {
+		p.Forward()
+
+		for name := p.ReadName(); name != ""; name = p.ReadName() {
+			if p.SkipSpaces() == ':' {
+				p.Forward()
+
+				params[name], err = p.ReadValue()
+				if err != nil {
+					return nil, err
+				}
+			}
+
+			if p.SkipSpaces() == ',' {
+				p.Forward()
 			}
 		}
 	}
 
 	p.SkipPastTag()
-	return &Include{value, config.GetIncludeHandler(), scopeType, scope, params}, nil
-}
 
-func readParameters(p *core.Parser) (map[string]core.Value, error) {
-	p.Forward()
-	parameters := make(map[string]core.Value)
-
-	for name := p.ReadName(); name != ""; name = p.ReadName() {
-		if p.SkipSpaces() == ':' {
-			p.Forward()
-			value, err := p.ReadValue()
-			if err != nil {
-				return nil, err
-			}
-			parameters[name] = value
-		}
-
-		if p.SkipSpaces() == ',' {
-			p.Forward()
-		}
-	}
-
-	return parameters, nil
+	return &Include{
+		includeName: includeName,
+		handler:     config.GetIncludeHandler(),
+		scopeType:   scopeType,
+		scopeKey:    scopeKey,
+		scope:       scope,
+		parameters:  params,
+	}, nil
 }
 
 type Include struct {
-	value      core.Value
-	handler    core.IncludeHandler
-	scopeType  string
-	scope      core.Value
-	parameters map[string]core.Value
+	includeName core.Value
+	handler     core.IncludeHandler
+	scopeType   string
+	scopeKey    string
+	scope       core.Value
+	parameters  map[string]core.Value
 }
 
 func (i *Include) AddCode(code core.Code) {
@@ -93,57 +97,44 @@ func (i *Include) LastSibling() core.Tag {
 }
 
 func (i *Include) Execute(writer io.Writer, data map[string]interface{}) core.ExecuteState {
-	template := core.ToString(i.value.Resolve(data))
-	_, filename := filepath.Split(template)
-	extension := filepath.Ext(filename)
-	name := filename[0 : len(filename)-len(extension)]
-	contextVariableName := strings.ToLower(name)
+	if i.handler == nil {
+		return core.Normal
+	}
 
-	var templateData = make([]map[string]interface{}, 1)
-	var parameterData = make(map[string]interface{}, len(i.parameters))
+	template := core.ToString(i.includeName.Resolve(data))
 
 	// Resolve values for all our parameters
-	for name, value := range i.parameters {
-		parameterData[name] = value.Resolve(data)
+	for key, value := range i.parameters {
+		data[key] = value.Resolve(data)
 	}
 
-	switch i.scopeType {
-	case "with":
-		scopedData := i.scope.Resolve(data)
-		templateData[0] = toMap(scopedData, contextVariableName)
-	case "for":
-		scopedData := i.scope.Resolve(data)
+	if i.scope != nil {
+		scope := i.scope.Resolve(data)
 
-		// Resolve returns a byte array when resolved data is nil that we can't do
-		// anything with. Bail so we dont just iterate through an array of bytes.
-		if _, ok := scopedData.([]byte); ok {
-			return core.Normal
-		}
+		if i.scopeType == includeForScopeType {
+			// Resolve returns a byte array when resolved data is nil that we can't do
+			// anything with. Bail so we dont just iterate through an array of bytes.
+			if _, byteOk := scope.([]byte); !byteOk {
 
-		switch reflect.TypeOf(scopedData).Kind() {
-		case reflect.Slice:
-			// Use reflection to iterate over ANY kind of slice (except []byte - see above)
-			slice := reflect.ValueOf(scopedData)
-			templateData = make([]map[string]interface{}, slice.Len())
-			for i := 0; i < slice.Len(); i++ {
-				templateData[i] = toMap(slice.Index(i).Interface(), contextVariableName)
+				switch reflect.TypeOf(scope).Kind() {
+				case reflect.Slice:
+					s := reflect.ValueOf(scope)
+
+					for idx := 0; idx < s.Len(); idx++ {
+						data[i.scopeKey] = s.Index(idx).Interface()
+						i.handler(template, writer, data)
+					}
+				}
+
+				return core.Normal
 			}
-		default:
-			templateData[0] = toMap(scopedData, contextVariableName)
 		}
-	default:
-		templateData[0] = data
+
+		data[i.scopeKey] = scope
 	}
 
-	if i.handler != nil {
-		for _, item := range templateData {
-			// Inject our parameters into the data context for the template
-			for name, value := range parameterData {
-				item[name] = value
-			}
-			i.handler(template, writer, item)
-		}
-	}
+	i.handler(template, writer, data)
+
 	return core.Normal
 }
 

--- a/tags/include.go
+++ b/tags/include.go
@@ -138,20 +138,6 @@ func (i *Include) Execute(writer io.Writer, data map[string]interface{}) core.Ex
 	return core.Normal
 }
 
-func toMap(data interface{}, contextVariableName string) map[string]interface{} {
-	if data == nil {
-		return nil
-	}
-
-	if typed, ok := data.(map[string]interface{}); ok {
-		return typed
-	}
-
-	context := make(map[string]interface{})
-	context[contextVariableName] = data
-	return context
-}
-
 func (i *Include) Name() string {
 	return "include"
 }

--- a/tags/include_test.go
+++ b/tags/include_test.go
@@ -46,8 +46,11 @@ func TestIncludeTagWithExecutes(t *testing.T) {
 	testData["context"] = testContext
 
 	config := new(core.Configuration).IncludeHandler(func(name string, writer io.Writer, data map[string]interface{}) {
-		writer.Write([]byte(fmt.Sprintf("%v", data["key"])))
+		dataMap, ok := data["test"].(map[string]interface{})
+		spec.Expect(ok, true)
+		writer.Write([]byte(fmt.Sprintf("%v", dataMap["key"])))
 	})
+
 	tag, err := IncludeFactory(parser, config)
 
 	spec.Expect(err).ToBeNil()
@@ -107,7 +110,9 @@ func TestIncludeTagWithWithParametersExecutes(t *testing.T) {
 	testData["context"] = testContext
 
 	config := new(core.Configuration).IncludeHandler(func(name string, writer io.Writer, data map[string]interface{}) {
-		writer.Write([]byte(fmt.Sprintf("%v,%v,%v", data["key"], data["test1"], data["test2"])))
+		dataMap, ok := data["test"].(map[string]interface{})
+		spec.Expect(ok, true)
+		writer.Write([]byte(fmt.Sprintf("%v,%v,%v", dataMap["key"], data["test1"], data["test2"])))
 	})
 	tag, err := IncludeFactory(parser, config)
 


### PR DESCRIPTION
cc @joshua @mgolus @mattbronkema 

When we first wrote the additional code for the 'with' and 'for' modifiers on the include tags, we were a bit off with our mapping. We were treating any maps as the main context instead of the include template name as the context key with the map as the value.

Examples

Context:
{item = {address = {city: Charleston, state: SC}}
item.address.city = "Charleston"

{include 'address.liq' with item.address}

Include Context:

Old:
{city: Charleston, state: SC}
city = "Charleston"

New:
{address = {City: Charleston, State: SC}}
address.city = "Charleston"

See https://github.com/Shopify/liquid/blob/master/lib/liquid/tags/include.rb#L58 for example of implementation. I tried to replicate the fall through of "isarray" by allowing the context to be set even if we did not support the array type.
