### PR TITLE
Fix #13 {% for … reversed %}, and #14 error message

### DIFF
--- a/tags/for.go
+++ b/tags/for.go
@@ -61,12 +61,13 @@ func ForFactory(p *core.Parser, config *core.Configuration) (core.Tag, error) {
 				return nil, err
 			}
 			f.offset = offset
-		} else if name == "reverse" {
-			f.reverse = true
+		} else if name == "reversed" {
+			f.reversed = true
 		} else {
 			return nil, p.Error(fmt.Sprintf("%q is an unknown attribute in for tag", name))
 		}
 	}
+
 	p.SkipPastTag()
 	return f, nil
 }
@@ -80,7 +81,7 @@ type For struct {
 	name      string
 	keyName   string
 	valueName string
-	reverse   bool
+	reversed  bool
 	limit     core.Value
 	offset    core.Value
 	value     core.Value
@@ -152,7 +153,7 @@ func (f *For) Type() core.TagType {
 
 func (f *For) iterateArray(state *LoopState, value reflect.Value, isString bool) {
 	length := state.Length
-	if f.reverse {
+	if f.reversed {
 		for i := length - 1; i >= 0; i-- {
 			if state := f.iterateArrayIndex(i, state, value, isString); state == core.Break {
 				return
@@ -181,7 +182,7 @@ func (f *For) iterateArrayIndex(i int, state *LoopState, value reflect.Value, is
 func (f *For) iterateMap(state *LoopState, value reflect.Value) {
 	keys := value.MapKeys()
 	length := state.Length
-	if f.reverse {
+	if f.reversed {
 		for i := length - 1; i >= 0; i-- {
 			if state := f.iterateMapIndex(i, state, keys, value); state == core.Break {
 				return
@@ -207,7 +208,7 @@ func (f *For) iterateMapIndex(i int, state *LoopState, keys []reflect.Value, val
 
 func (f *For) loopIteration(state *LoopState, i int) {
 	l1 := state.Length - 1
-	if f.reverse {
+	if f.reversed {
 		state.Index = state.Length - i
 		state.Index0 = l1 - i
 		state.RIndex = i + 1

--- a/tags/for.go
+++ b/tags/for.go
@@ -64,7 +64,7 @@ func ForFactory(p *core.Parser, config *core.Configuration) (core.Tag, error) {
 		} else if name == "reverse" {
 			f.reverse = true
 		} else {
-			return nil, p.Error(fmt.Sprint("%q is an inknown modifier in for tag", name))
+			return nil, p.Error(fmt.Sprintf("%q is an unknown attribute in for tag", name))
 		}
 	}
 	p.SkipPastTag()

--- a/template_test.go
+++ b/template_test.go
@@ -1,6 +1,7 @@
 package liquid
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/karlseguin/gspec"
@@ -115,6 +116,14 @@ func TestRendersCaseElse(t *testing.T) {
 	assertRender(t, template, nil, `A-else-Z`)
 }
 
+func TestRendersForReversed(t *testing.T) {
+	data := map[string]interface{}{
+		"array": []int{1, 2, 3},
+	}
+	template, _ := ParseString("A-{% for item in array reversed %}{{item}}{% endfor%}-Z", nil)
+	assertRender(t, template, data, `A-321-Z`)
+}
+
 func TestRendersUnknownForAttribute(t *testing.T) {
 	template, err := ParseString("A-{% for item in array unknown %}{% endfor%}-Z", nil)
 	if template != nil {
@@ -128,7 +137,7 @@ func TestRendersUnknownForAttribute(t *testing.T) {
 
 var complexTemplate = `
 Out of
-{% for color in colors reverse %}
+{% for color in colors reversed %}
 - {{ color}}
 {% endfor %}
 {% capture favorite %}{{ colors |first}}{%endcapture%}

--- a/template_test.go
+++ b/template_test.go
@@ -115,6 +115,17 @@ func TestRendersCaseElse(t *testing.T) {
 	assertRender(t, template, nil, `A-else-Z`)
 }
 
+func TestRendersUnknownForAttribute(t *testing.T) {
+	template, err := ParseString("A-{% for item in array unknown %}{% endfor%}-Z", nil)
+	if template != nil {
+		t.Errorf("fail")
+	}
+	expected := "\"unknown\" is an unknown attribute in for tag"
+	if !strings.HasPrefix(err.Error(), expected) {
+		t.Errorf("Expecting %q..., got %q", expected, err)
+	}
+}
+
 var complexTemplate = `
 Out of
 {% for color in colors reverse %}


### PR DESCRIPTION
Tested via new test cases and `./t`.

This enables this library to work with some Jekyll templates that they formerly failed on.